### PR TITLE
Fix data dictionary

### DIFF
--- a/sleep/Data Dictionary.md
+++ b/sleep/Data Dictionary.md
@@ -372,7 +372,7 @@
 	- Possible values are:
 		- 18-29
 		- 45-60
-		- > 60
+		- \> 60
 		- 30-44
 
 - Household Income are


### PR DESCRIPTION
This escapes the markdown character for blockquote in the data dictionary as one of the characters is a `>`